### PR TITLE
Report the real returned buffer size from the compress path (fixes writes under HDF5 2.2.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0074 NEW)
 project(blosc2_hdf5)
 include(ExternalProject)
@@ -50,7 +50,6 @@ else(MSVC)
     find_package(HDF5 REQUIRED)
 endif(MSVC)
 include_directories(${HDF5_INCLUDE_DIRS})
-include_directories("/mnt/c/Users/sosca/CLionProjects/build/include")
 
 
 # add blosc2 libraries
@@ -78,11 +77,6 @@ install(FILES src/blosc2_filter.h DESTINATION include COMPONENT HDF5_FILTER_DEV)
 install(TARGETS blosc2_filter_shared DESTINATION lib COMPONENT HDF5_FILTER_DEV)
 
 
-# add caterva library
-add_library(CAT_LIBRARY SHARED IMPORTED)
-set_target_properties(CAT_LIBRARY PROPERTIES IMPORTED_LOCATION "/mnt/c/Users/sosca/CLionProjects/build/libs/release/libcaterva.so")
-
-
 # test
 message("LINK LIBRARIES='blosc2_filter_shared ${HDF5_LIBRARIES}'")
 if(BUILD_TESTS)
@@ -93,7 +87,4 @@ if(BUILD_TESTS)
     add_executable(example executables/example.c)
     target_link_libraries(example blosc2_filter_shared ${HDF5_LIBRARIES} ${LIBS})
     add_test(test_hdf5_filter example)
-    add_executable(test_blosc2_filter_read executables/test_blosc2_filter_read.c)
-    target_link_libraries(test_blosc2_filter_read blosc2_filter_shared ${HDF5_LIBRARIES} ${LIBS} CAT_LIBRARY)
-    add_test(test_hdf5_filter test_blosc2_filter_read)
 endif(BUILD_TESTS)

--- a/src/blosc2_filter.c
+++ b/src/blosc2_filter.c
@@ -454,6 +454,15 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
 
     }
 
+    if (status > 0) {
+      /* The cframe returned by Blosc2 is exactly `status` bytes long.  Report
+       * its real size instead of the precomputed guess: when the frame is
+       * larger than the guess (e.g. incompressible data), HDF5 >= 2.2.0
+       * rejects the write if the reported buffer size is smaller than the
+       * returned data size. */
+      outbuf_size = (size_t) status;
+    }
+
 #ifdef BLOSC2_DEBUG
     fprintf(stderr, "Blosc2: Compressed into %zd bytes\n", status);
 #endif


### PR DESCRIPTION
HDF5 2.2.0 (released 2026-07-29) added a consistency check to `H5Z_pipeline` (absent in <= 2.1.1): after a filter callback returns, the reported data size must not exceed the reported buffer size, otherwise the pipeline fails with `buffer size is too small after filter callback`.

The compress path of this filter trips that check. It returns the cframe produced by `b2nd_to_cframe()` / `blosc2_schunk_to_buffer()` — a buffer allocated by Blosc2 that is exactly `status` bytes long — but reports `*buf_size` as the *precomputed guess* from `cd_values[3]`. Whenever the actual frame is larger than the guess (e.g. incompressible data, where the Blosc2 frame format adds overhead), the filter reports a data size larger than the claimed buffer size. Memory-wise this was always fine (the real allocation is `status` bytes), but under HDF5 >= 2.2.0 the stale bookkeeping becomes a hard failure: chunk flushes error out (writes fail), or chunks are never written and read back as fill values.

The fix reports the real size of the returned buffer.

## How this was found and verified

PyTables vendors this filter (the affected code is identical). Moving PyTables wheels to HDF5 2.2.0 (PyTables/PyTables#1347) produced 44 failures + 8 errors, all in `Blosc2*` test cases, with this HDF5 error trace on writes:

```
  File ".../H5Dchunk.c", line 4289, in H5D__chunk_flush_entry
    output pipeline failed
  File ".../H5Z.c", line 1607, in H5Z_pipeline
    buffer size is too small after filter callback
```

With this one-line fix, the full PyTables suite (6854 tests) passes against HDF5 1.14.6, 2.0.0, 2.1.1, and 2.2.0 — i.e. the fix repairs 2.2.0 and does not change behavior on older HDF5, which never inspected the reported buffer size in this situation.

A second commit makes the default build usable for verifying this on current toolchains: `cmake_minimum_required` 2.8.10 → 3.5 (CMake 4 refuses to configure below 3.5), and removal of the hardcoded developer-machine include path and caterva import library (fixes #2) together with the `test_blosc2_filter_read` target that required them — it has not been buildable since caterva was merged into c-blosc2 as b2nd. With that, `cmake -S . -B build && cmake --build build && ctest` passes against HDF5 2.2.0 on macOS arm64.
